### PR TITLE
Add certification category and engineer certification career entry

### DIFF
--- a/src/components/IconPaths.ts
+++ b/src/components/IconPaths.ts
@@ -32,4 +32,5 @@ export const iconPaths = {
 	'linkedin-logo': `<rect width="184" height="184" x="36" y="36" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" rx="8"/><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" d="M120 112v64m-32-64v64m32-36a28 28 0 0 1 56 0v36"/><circle stroke="none" cx="88" cy="80" r="12"/>`,
 	briefcase: `<rect x="32" y="72" width="192" height="144" rx="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M80,72V48a16,16,0,0,1,16-16h64a16,16,0,0,1,16,16V72" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>`,
 	bank: `<path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" d="M28.16 72 128 16l99.84 56ZM56 96v88M104 96v88M152 96v88M200 96v88M32 216h192M40 184h176"/>`,
+	medal: `<circle cx="128" cy="168" r="56" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" d="M88 132 56 24l72 32 72-32-32 108"/>`,
 };

--- a/src/pages/career.astro
+++ b/src/pages/career.astro
@@ -130,6 +130,15 @@ const careerData = [
         description: "Migration of bank accounts from Bulgaria to Euro.",
     },
     {
+        type: "certification",
+        title: "Engineer Certification",
+        organization: "WKO Upper Austria",
+        startDate: "2026-01-01",
+        endDate: "2026-01-01",
+        description:
+            "Successfully completed the Engineer Certification.",
+    },
+    {
         type: "hackathon",
         title: "Raiffeisen Arena Hackathon",
         organization: "Developer",
@@ -173,6 +182,8 @@ const getIcon = (type: string) => {
             return "pencil-line";
         case "hackathon":
             return "trophy";
+        case "certification":
+            return "medal";
         default:
             return "star";
     }
@@ -188,6 +199,8 @@ const getTypeLabel = (type: string) => {
             return "Side Project";
         case "hackathon":
             return "Hackathon";
+        case "certification":
+            return "Certification";
         default:
             return "Entry";
     }

--- a/src/pages/de/career.astro
+++ b/src/pages/de/career.astro
@@ -131,6 +131,15 @@ const careerData = [
         description: "Migration der Bankverbindungen aus Bulgarien auf Euro",
     },
     {
+        type: "certification",
+        title: "Ingenieur Zertifizierung",
+        organization: "WKO Oberösterreich",
+        startDate: "2026-01-01",
+        endDate: "2026-01-01",
+        description:
+            "Erfolgreicher Abschluss der Ingenieur-Zertifizierung.",
+    },
+    {
         type: "hackathon",
         title: "Raiffeisen Arena Hackathon",
         organization: "Developer",
@@ -174,6 +183,8 @@ const getIcon = (type: string) => {
             return "pencil-line";
         case "hackathon":
             return "trophy";
+        case "certification":
+            return "medal";
         default:
             return "star";
     }
@@ -189,6 +200,8 @@ const getTypeLabel = (type: string) => {
             return "Nebenprojekt";
         case "hackathon":
             return "Hackathon";
+        case "certification":
+            return "Zertifizierung";
         default:
             return "Eintrag";
     }


### PR DESCRIPTION
Adds a new "certification" career type (Zertifizierung/Certification)
with a dedicated medal icon, and adds the 2026 engineer certification
(WKO Oberösterreich) as a new career timeline entry in both the
English and German career pages.

https://claude.ai/code/session_012yHtVpnEfuxvagVMjDFuD3