### PR TITLE
Rebrand Family OS to myfaos, mark as live

### DIFF
--- a/src/content/work/de/myfaos.md
+++ b/src/content/work/de/myfaos.md
@@ -1,12 +1,12 @@
 ---
-title: Family OS
+title: myfaos
 publishDate: 2025-03-01 00:00:00
-url: https://0815family-os.vercel.app
-status: preview
+url: https://www.myfaos.app
+status: live
 description: Die operative Schicht für das Familienleben — gemeinsamer Kalender, Haushaltsaufgaben und Dokumentation für Kinder, alles in einem privaten Hub. Für Familien mit jungen Kindern.
 tags:
   - Family
   - Productivity
-  - Preview
+  - Web App
   - Side Project
 ---

--- a/src/content/work/de/myfaos.md
+++ b/src/content/work/de/myfaos.md
@@ -1,6 +1,6 @@
 ---
-title: myfaos
-publishDate: 2025-03-01 00:00:00
+title: myFAOS
+publishDate: 2024-08-15 00:00:00
 url: https://www.myfaos.app
 status: live
 description: Die operative Schicht für das Familienleben — gemeinsamer Kalender, Haushaltsaufgaben und Dokumentation für Kinder, alles in einem privaten Hub. Für Familien mit jungen Kindern.

--- a/src/content/work/myfaos.md
+++ b/src/content/work/myfaos.md
@@ -1,6 +1,6 @@
 ---
-title: myfaos
-publishDate: 2025-03-01 00:00:00
+title: myFAOS
+publishDate: 2024-08-15 00:00:00
 url: https://www.myfaos.app
 status: live
 description: The operational layer for family life — shared calendar, household tasks, and child documentation in one private hub. Built for families with young children.

--- a/src/content/work/myfaos.md
+++ b/src/content/work/myfaos.md
@@ -1,12 +1,12 @@
 ---
-title: Family OS
+title: myfaos
 publishDate: 2025-03-01 00:00:00
-url: https://0815family-os.vercel.app
-status: preview
+url: https://www.myfaos.app
+status: live
 description: The operational layer for family life — shared calendar, household tasks, and child documentation in one private hub. Built for families with young children.
 tags:
   - Family
   - Productivity
-  - Preview
+  - Web App
   - Side Project
 ---


### PR DESCRIPTION
Renamed the project entry (and file) from family-os to myfaos, updated
the URL to www.myfaos.app, and flipped status from preview to live in
both English and German content.