### PR TITLE
Drop the start date from the project detail hero

### DIFF
--- a/src/components/ProjectDetail.astro
+++ b/src/components/ProjectDetail.astro
@@ -18,10 +18,6 @@ const t = copy[lang];
 
 const backHref = lang === 'de' ? '/de/work' : '/work/';
 const statusLabel = data.status === 'live' ? t.live : data.status === 'preview' ? t.preview : null;
-const started = data.publishDate.toLocaleDateString(lang === 'de' ? 'de-AT' : 'en-GB', {
-	month: 'long',
-	year: 'numeric',
-});
 
 const { Content } = await render(entry);
 ---
@@ -36,10 +32,14 @@ const { Content } = await render(entry);
 
 			<div class="hero stack gap-4">
 				<div class="stack gap-2">
-					<div class="meta">
-						{statusLabel && <Pill>{statusLabel}</Pill>}
-						<span class="started">{t.published} {started}</span>
-					</div>
+					{
+						statusLabel && (
+							/* Wrapper keeps the pill at its natural width inside the column. */
+							<div class="meta">
+								<Pill>{statusLabel}</Pill>
+							</div>
+						)
+					}
 					<h1 class="title">{data.title}</h1>
 					<p class="tagline">{data.tagline ?? data.description}</p>
 				</div>
@@ -120,12 +120,6 @@ const { Content } = await render(entry);
 		align-items: center;
 		flex-wrap: wrap;
 		gap: 0.75rem;
-	}
-
-	.started {
-		font-family: var(--font-brand);
-		font-size: var(--text-sm);
-		color: var(--gray-400);
 	}
 
 	.title {

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -23,7 +23,6 @@ export const project = {
         close: 'Close image',
         live: 'Live',
         preview: 'Preview',
-        published: 'Started',
     },
     de: {
         back: 'Alle Projekte',
@@ -34,7 +33,6 @@ export const project = {
         close: 'Bild schließen',
         live: 'Live',
         preview: 'Vorschau',
-        published: 'Gestartet',
     },
 } as const;
 


### PR DESCRIPTION
Follow-up to #33, which is already merged.

The `Started <month year>` / `Gestartet <Monat Jahr>` line sat above each project title on the detail pages. It added a date nobody needs on the way into the page — the status pill already carries the only state that matters there.

## Changes

- Remove the date line and its `.started` styles from `ProjectDetail.astro`.
- Remove the now-unused `published` string from both locales in `i18n/ui.ts`.
- Keep the wrapper around the status pill. Without it the pill stretches to the full column width, since it is a flex child in a column layout.

`publishDate` stays in the collection schema — `/work` and the homepage still sort by it.

## Verification

`npm run build` (which runs `astro check`) passes, all 21 pages build. Detail pages checked in both languages; the rendered HTML no longer contains `Started` or `Gestartet`.

---

_Correction: this description briefly listed four unrelated fixes (language detection, fonts, image delivery, social cards). Those were pushed to the same branch after this PR had already merged, so they were never part of it. They live in their own follow-up PR; this one is the two-file change described above._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkUnfUtowjp9tPEoW9ofY9