### PR TITLE
Share the theme with the CV and the blog

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import { buildGraph, BRAND, FULL_NAME, type JsonLdNode } from '../lib/schema';
+import { themeInitScript } from '../lib/theme';
 
 interface Props {
 	title?: string | undefined;
@@ -122,23 +123,6 @@ const jsonLd = buildGraph(isDe ? 'de' : 'en', schema);
 	media="print"
 	onload="this.media='all'"
 />
-<script is:inline>
-	// This code is inlined in the head to make dark mode instant & blocking.
-	const getThemePreference = () => {
-		if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-			return localStorage.getItem('theme');
-		}
-		return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-	};
-	const isDark = getThemePreference() === 'dark';
-	document.documentElement.classList[isDark ? 'add' : 'remove']('theme-dark');
-
-	if (typeof localStorage !== 'undefined') {
-		// Watch the document element and persist user preference when it changes.
-		const observer = new MutationObserver(() => {
-			const isDark = document.documentElement.classList.contains('theme-dark');
-			localStorage.setItem('theme', isDark ? 'dark' : 'light');
-		});
-		observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
-	}
-</script>
+<!-- Inlined in the head to make dark mode instant & blocking. Shares the
+     choice with the CV and the blog — see src/lib/theme.ts. -->
+<script is:inline set:html={themeInitScript} />

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -68,27 +68,36 @@ import Icon from './Icon.astro';
 </style>
 
 <script>
+	import { applyTheme, isDark, storeTheme } from '../lib/theme';
+
 	class ThemeToggle extends HTMLElement {
 		constructor() {
 			super();
 
 			const button = this.querySelector('button')!;
 
-			/** Set the theme to dark/light mode. */
-			const setTheme = (dark: boolean) => {
-				document.documentElement.classList[dark ? 'add' : 'remove']('theme-dark');
-				button.setAttribute('aria-pressed', String(dark));
-			};
+			/** Mirror whatever theme the document currently carries. */
+			const reflect = () => button.setAttribute('aria-pressed', String(isDark()));
 
-			// Toggle the theme when a user clicks the button.
-			button.addEventListener('click', () => setTheme(!this.isDark()));
+			// Toggle the theme when a user clicks the button, and persist it so the
+			// CV and the blog pick the same one up — see src/lib/theme.ts.
+			button.addEventListener('click', () => {
+				const next = isDark() ? 'light' : 'dark';
+				applyTheme(next);
+				storeTheme(next);
+				reflect();
+			});
+
+			// The head script switches the theme on its own when a sibling site
+			// changed it while this tab was in the background, so follow the class
+			// rather than assume this button is the only thing that moves it.
+			new MutationObserver(reflect).observe(document.documentElement, {
+				attributes: true,
+				attributeFilter: ['class'],
+			});
 
 			// Initialize button state to reflect current theme.
-			setTheme(this.isDark());
-		}
-
-		isDark() {
-			return document.documentElement.classList.contains('theme-dark');
+			reflect();
 		}
 	}
 	customElements.define('theme-toggle', ThemeToggle);

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,132 @@
+/**
+ * Theme storage shared with the CV (cv.gnadlinger.me) and the blog
+ * (blog.gnadlinger.me).
+ *
+ * Those are separate deployments, so localStorage — which is scoped to one
+ * origin — cannot carry the theme across the links between them. What the
+ * three sites do share is the registrable domain, so the choice is mirrored
+ * into a cookie scoped to it and every site reads that first. localStorage
+ * stays as the per-site copy, which keeps working on localhost and on preview
+ * deployments, where the shared domain does not apply.
+ */
+export const THEME_COOKIE_KEY = 'theme';
+export const THEME_STORAGE_KEY = 'theme';
+export const THEME_COOKIE_DOMAIN = 'gnadlinger.me';
+export const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+/** The class that puts this site into dark mode. */
+export const DARK_CLASS = 'theme-dark';
+
+export type Theme = 'light' | 'dark';
+
+export function isDark(): boolean {
+	return document.documentElement.classList.contains(DARK_CLASS);
+}
+
+export function applyTheme(theme: Theme) {
+	document.documentElement.classList.toggle(DARK_CLASS, theme === 'dark');
+}
+
+export function readCookieTheme(): Theme | null {
+	const match = document.cookie.match(
+		new RegExp(`(?:^|;\\s*)${THEME_COOKIE_KEY}=(dark|light)(?:\\s*;|$)`)
+	);
+	return match ? (match[1] as Theme) : null;
+}
+
+export function readStoredTheme(): Theme | null {
+	try {
+		const stored = localStorage.getItem(THEME_STORAGE_KEY);
+		return stored === 'dark' || stored === 'light' ? stored : null;
+	} catch {
+		return null;
+	}
+}
+
+export function storeTheme(theme: Theme) {
+	try {
+		localStorage.setItem(THEME_STORAGE_KEY, theme);
+	} catch {
+		// Private mode and friends: the cookie below still keeps the session
+		// consistent, so a blocked localStorage is not worth failing over.
+	}
+
+	const host = location.hostname;
+	const shared =
+		host === THEME_COOKIE_DOMAIN || host.endsWith(`.${THEME_COOKIE_DOMAIN}`)
+			? `; domain=.${THEME_COOKIE_DOMAIN}`
+			: '';
+	const secure = location.protocol === 'https:' ? '; Secure' : '';
+	document.cookie = `${THEME_COOKIE_KEY}=${theme}; path=/; max-age=${THEME_COOKIE_MAX_AGE}; SameSite=Lax${shared}${secure}`;
+}
+
+/**
+ * Applies the theme before first paint, so dark mode never flashes white, and
+ * keeps this tab in step with a theme switched on one of the sibling sites.
+ * Inlined into the head as a raw string, ahead of any bundle.
+ */
+export const themeInitScript = `(function () {
+  var COOKIE = ${JSON.stringify(THEME_COOKIE_KEY)};
+  var STORAGE = ${JSON.stringify(THEME_STORAGE_KEY)};
+  var DOMAIN = ${JSON.stringify(THEME_COOKIE_DOMAIN)};
+  var DARK = ${JSON.stringify(DARK_CLASS)};
+  var MAX_AGE = ${THEME_COOKIE_MAX_AGE};
+  var VALUE = /^(dark|light)$/;
+
+  function fromCookie() {
+    var match = document.cookie.match(new RegExp("(?:^|;\\\\s*)" + COOKIE + "=(dark|light)(?:\\\\s*;|$)"));
+    return match ? match[1] : null;
+  }
+
+  function fromStorage() {
+    try {
+      var stored = localStorage.getItem(STORAGE);
+      return VALUE.test(stored) ? stored : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function toStorage(theme) {
+    try {
+      localStorage.setItem(STORAGE, theme);
+    } catch (error) {}
+  }
+
+  function toCookie(theme) {
+    var host = location.hostname;
+    var shared = host === DOMAIN || host.slice(-DOMAIN.length - 1) === "." + DOMAIN ? "; domain=." + DOMAIN : "";
+    var secure = location.protocol === "https:" ? "; Secure" : "";
+    document.cookie = COOKIE + "=" + theme + "; path=/; max-age=" + MAX_AGE + "; SameSite=Lax" + shared + secure;
+  }
+
+  function sync() {
+    var shared = fromCookie();
+    var local = fromStorage();
+    var theme = shared || local;
+
+    if (theme) {
+      // Refreshes the cookie's lifetime, seeds it for visitors whose choice
+      // predates it, and adopts a theme picked on one of the sibling sites.
+      toCookie(theme);
+      if (theme !== local) toStorage(theme);
+    } else {
+      theme = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+
+    document.documentElement.classList.toggle(DARK, theme === "dark");
+  }
+
+  sync();
+
+  // The CV and the blog are linked with target="_blank", so both tabs stay
+  // open and the theme may have been switched in the other one meanwhile.
+  addEventListener("visibilitychange", function () {
+    if (!document.hidden) sync();
+  });
+  addEventListener("focus", sync);
+  addEventListener("pageshow", function (event) {
+    if (event.persisted) sync();
+  });
+  document.addEventListener("astro:after-swap", sync);
+})();`;


### PR DESCRIPTION
Following the CV or Blog button from here dropped the visitor into a different theme than the one they were just looking at.

## Why

The portfolio, the CV and the blog each kept the light/dark choice in their own `localStorage`, and that is scoped to one origin — `www.gnadlinger.me` cannot read what `cv.gnadlinger.me` stored. So each site fell back to whatever it had saved before, or to the system default.

## What changed

All three run on the same registrable domain, so the choice is now mirrored into a `theme` cookie on `.gnadlinger.me`, which every site reads before its own copy. No link changes were needed — this also works for bookmarks and typed URLs.

- Read order: cookie → own `localStorage` → `prefers-color-scheme`.
- An existing `localStorage` value seeds the cookie on the next visit, so a returning visitor keeps the theme they picked.
- With no explicit choice anywhere, nothing is persisted — the system setting stays in charge instead of being frozen in.
- On `localhost` and preview deployments the cookie is written host-only, so the browser does not drop it.
- The links open in a new tab, so the head script re-reads the cookie when the tab comes back into view (`visibilitychange` / `focus` / bfcache). Switching the theme in the CV tab repaints this one too.

Locally: `src/lib/theme.ts` now holds the theme logic that the toggle and the inlined head script share, replacing the `MutationObserver` persistence in `MainHead`. The toggle follows the `theme-dark` class rather than assuming it is the only thing that moves it, so `aria-pressed` stays correct when a sibling site changes the theme.

The cookie is a functional preference cookie, set only when the visitor actually toggles — no tracking.

## Verification

- End-to-end with Playwright against all three real subdomains (mapped locally to the built sites via `/etc/hosts`): portfolio → dark, CV and blog open dark; switch to light on the CV, and the already-open blog and portfolio tabs follow, as does a fresh visit; a legacy `localStorage` choice is adopted; with nothing chosen the system preference wins. All green.
- `astro check && astro build` green.

Companion PRs: Gnadi/cv and Gnadi/myblog — all three need to be deployed for the theme to travel in every direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCjYX4mgW1uEgPk6vS4wU8)_