### PR TITLE
Offer a one-click AI summary of the current page

### DIFF
--- a/src/components/AskAi.astro
+++ b/src/components/AskAi.astro
@@ -1,0 +1,113 @@
+---
+/**
+ * A row of AI assistants, each linking out with a summary of the current page
+ * already prefilled. See src/lib/askAi.ts for the prompt and the link formats.
+ */
+import { getLangFromUrl } from '../i18n/utils';
+import { buildPrompt, labels, providers } from '../lib/askAi';
+
+interface Props {
+	/** The page's `<title>`, same value BaseLayout passes to MainHead. */
+	title: string;
+	/** The page's meta description. */
+	description: string;
+}
+
+const { title, description } = Astro.props;
+
+const lang = getLangFromUrl(Astro.url);
+const copy = labels[lang];
+
+// Same resolution as the canonical link in MainHead: `Astro.url` carries the
+// build server's origin, so the public origin comes from astro.config.
+const site = Astro.site ?? new URL('https://www.gnadlinger.me/');
+const url = new URL(Astro.url.pathname, site).href;
+
+const prompt = encodeURIComponent(buildPrompt({ lang, title, description, url }));
+---
+
+<aside class="ask-ai" aria-label={copy.heading}>
+	<p class="heading">{copy.heading}</p>
+	<ul class="row" role="list">
+		{
+			providers.map(({ name, glyph, href }) => {
+				const action = copy.action.replace('%s', name);
+				return (
+					<li>
+						<a href={href(prompt)} target="_blank" rel="noopener noreferrer" title={action}>
+							<span class="sr-only">{action}</span>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								viewBox={glyph.viewBox}
+								fill="currentcolor"
+								aria-hidden="true"
+							>
+								<path d={glyph.path} />
+							</svg>
+						</a>
+					</li>
+				);
+			})
+		}
+	</ul>
+</aside>
+
+<style>
+	.ask-ai {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1rem;
+		margin-top: auto;
+		padding: 3rem 2rem 0;
+		text-align: center;
+	}
+
+	.heading {
+		color: var(--gray-400);
+		font-size: var(--text-sm);
+	}
+
+	.row {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 0;
+		margin: 0;
+		list-style: none;
+	}
+
+	a {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.75rem;
+		height: 2.75rem;
+		border-radius: 999rem;
+		background-color: var(--gray-999);
+		box-shadow: inset 0 0 0 1px var(--accent-overlay);
+		/* `--link-color` rather than the raw accent: it is the one that stays
+		   legible against the dark theme's near-black background. */
+		color: var(--link-color);
+	}
+
+	svg {
+		width: 1.25rem;
+		height: 1.25rem;
+	}
+
+	a:hover,
+	a:focus-visible {
+		background-color: var(--accent-regular);
+		color: var(--accent-text-over);
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		a {
+			transition:
+				background-color var(--theme-transition),
+				color var(--theme-transition);
+		}
+	}
+</style>

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -1,6 +1,13 @@
 ---
 import '../styles/global.css';
-import { buildGraph, BRAND, FULL_NAME, type JsonLdNode } from '../lib/schema';
+import {
+	buildGraph,
+	BRAND,
+	DEFAULT_DESCRIPTION,
+	DEFAULT_TITLE,
+	FULL_NAME,
+	type JsonLdNode,
+} from '../lib/schema';
 import { themeInitScript } from '../lib/theme';
 
 interface Props {
@@ -19,8 +26,8 @@ interface Props {
 }
 
 const {
-	title = `${BRAND} — ${FULL_NAME}, Backend Engineer`,
-	description = 'Johannes Gnadlinger — Backend Engineer for corporate payment systems and financial infrastructure, based in Linz, Austria.',
+	title = DEFAULT_TITLE,
+	description = DEFAULT_DESCRIPTION,
 	alternates = true,
 	schema = [],
 	ogType = 'website',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,8 +6,9 @@
 import MainHead from '../components/MainHead.astro';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
+import AskAi from '../components/AskAi.astro';
 import Analytics from '@vercel/analytics/astro';
-import type { JsonLdNode } from '../lib/schema';
+import { DEFAULT_DESCRIPTION, DEFAULT_TITLE, type JsonLdNode } from '../lib/schema';
 
 interface Props {
 	title?: string | undefined;
@@ -22,6 +23,9 @@ interface Props {
 	publishedTime?: Date | undefined;
 	/** Keep the page out of the index (404s). */
 	noindex?: boolean;
+	/** Offer the “summarise with AI” links. Off where there is nothing to
+	 *  summarise, i.e. the 404s. */
+	askAi?: boolean;
 }
 
 const {
@@ -32,6 +36,7 @@ const {
 	ogType,
 	publishedTime,
 	noindex,
+	askAi = true,
 } = Astro.props;
 
 const pathname = Astro.url.pathname;
@@ -56,6 +61,7 @@ const lang = pathname === '/de' || pathname.startsWith('/de/') ? 'de' : 'en';
 		<div class="stack backgrounds">
 			<Nav />
 			<slot />
+			{askAi && <AskAi title={title ?? DEFAULT_TITLE} description={description ?? DEFAULT_DESCRIPTION} />}
 			<Footer />
 		</div>
 

--- a/src/lib/askAi.ts
+++ b/src/lib/askAi.ts
@@ -1,0 +1,151 @@
+/**
+ * “Ask an AI about this page” — the row of assistant links above the footer.
+ *
+ * Each link opens an assistant's web app with a prompt already sitting in its
+ * input, so a visitor can hand the page they are on to whichever assistant
+ * they happen to use without retyping anything. The prompt rides along in the
+ * query string, which is why it is kept tight: Google's AI Mode is a plain
+ * search URL and truncates long queries, and browsers have their own URL
+ * ceilings on top of that.
+ *
+ * Nothing here runs on the client. The links are plain `<a href>` values built
+ * at build time, so the bar costs no JavaScript.
+ */
+
+import { SITE_ORIGIN } from './schema';
+import type { SiteLang } from '../i18n/ui';
+
+/** A brand mark, kept at its own viewBox instead of redrawn to match ours. */
+interface Glyph {
+	viewBox: string;
+	path: string;
+}
+
+export interface AiProvider {
+	id: string;
+	/** Used for the tooltip and the accessible name. */
+	name: string;
+	glyph: Glyph;
+	/** Builds the deep link. `prompt` arrives already URI-encoded. */
+	href(prompt: string): string;
+}
+
+/**
+ * The assistants that accept a prefilled prompt over the URL. Adding one is a
+ * single entry; the bar renders whatever is in this list.
+ *
+ * Google is listed as AI Mode rather than the Gemini app: the app has no
+ * documented prefill parameter, while AI Mode (`udm=50`) takes the prompt as
+ * an ordinary search query and answers with the same model.
+ */
+export const providers: AiProvider[] = [
+	{
+		id: 'chatgpt',
+		name: 'ChatGPT',
+		href: (prompt) => `https://chatgpt.com/?hints=search&q=${prompt}`,
+		glyph: {
+			viewBox: '0 0 24 24',
+			path: 'M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z',
+		},
+	},
+	{
+		id: 'claude',
+		name: 'Claude',
+		href: (prompt) => `https://claude.ai/new?q=${prompt}`,
+		glyph: {
+			viewBox: '0 0 24 24',
+			path: 'm4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z',
+		},
+	},
+	{
+		id: 'google',
+		name: 'Google AI Mode',
+		href: (prompt) => `https://www.google.com/search?udm=50&aep=11&q=${prompt}`,
+		glyph: {
+			viewBox: '0 0 24 24',
+			path: 'M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81',
+		},
+	},
+	{
+		id: 'perplexity',
+		name: 'Perplexity',
+		href: (prompt) => `https://www.perplexity.ai/search/new?q=${prompt}`,
+		glyph: {
+			viewBox: '0 0 24 24',
+			path: 'M22.3977 7.0896h-2.3106V.0676l-7.5094 6.3542V.1577h-1.1554v6.1966L4.4904 0v7.0896H1.6023v10.3976h2.8882V24l6.932-6.3591v6.2005h1.1554v-6.0469l6.9318 6.1807v-6.4879h2.8882V7.0896zm-3.4657-4.531v4.531h-5.355l5.355-4.531zm-13.2862.0676 4.8691 4.4634H5.6458V2.6262zM2.7576 16.332V8.245h7.8476l-6.1149 6.1147v1.9723H2.7576zm2.8882 5.0404v-3.8852h.0001v-2.6488l5.7763-5.7764v7.0111l-5.7764 5.2993zm12.7086.0248-5.7766-5.1509V9.0618l5.7766 5.7766v6.5588zm2.8882-5.0652h-1.733v-1.9723L13.3948 8.245h7.8478v8.087z',
+		},
+	},
+];
+
+/** Every page title carries the brand; the prompt does not need it twice. */
+function stripBrand(title: string): string {
+	return title.replace(/\s*\|\s*Gnadlinger\s*$/, '').trim();
+}
+
+export interface PromptInput {
+	lang: SiteLang;
+	/** The page's `<title>`, brand suffix and all. */
+	title: string;
+	/** The page's meta description. */
+	description: string;
+	/** Absolute URL of the page — the assistant fetches this to read it. */
+	url: string;
+}
+
+/**
+ * The prompt handed to the assistant. It names the page and points at
+ * `llms.txt` for the site-wide context, so the answer is grounded in this
+ * site rather than in whatever the model happens to remember about the name.
+ */
+export function buildPrompt({ lang, title, description, url }: PromptInput): string {
+	const page = stripBrand(title);
+
+	if (lang === 'de') {
+		return [
+			'Du hilfst jemandem, der gerade eine Seite auf gnadlinger.me liest — der persönlichen Website von Johannes Gnadlinger, Backend Engineer bei der Raiffeisen Software GmbH in Linz. Sein Feld sind Corporate Payment Systems: SEPA- und EBICS-Strecken, Transaktionsverarbeitung und Private-Banking-Plattformen.',
+			'',
+			'Öffne die Seite unten und schreibe eine kurze, brauchbare Zusammenfassung (3–5 Sätze), die',
+			'- benennt, was konkret auf dieser Seite steht: Rollen, Projekte, Technologien und Jahreszahlen beim Namen, nicht in Adjektiven,',
+			'- herausarbeitet, was das über ihn als Engineer aussagt und wo seine Tiefe tatsächlich liegt,',
+			'- mit einem konkreten nächsten Schritt endet, den es auf der Seite gibt: eine andere Seite, ein Projekt oder ein Weg, ihn zu erreichen.',
+			'',
+			'Antworte in 2–3 kurzen Absätzen. Ton: direkt und sachlich, in der Du-Form. Kein Werbesprech — die Arbeit soll für sich sprechen.',
+			'',
+			`Seite: „${page}“ — ${url}`,
+			description ? `Kurzbeschreibung: ${description}` : null,
+			`Überblick über die Website: ${SITE_ORIGIN}/llms.txt`,
+		]
+			.filter((line) => line !== null)
+			.join('\n');
+	}
+
+	return [
+		'You are helping someone who is reading a page on gnadlinger.me, the personal site of Johannes Gnadlinger, a backend engineer at Raiffeisen Software in Linz, Austria. His field is corporate payment systems: SEPA and EBICS flows, transaction processing, and private banking platforms.',
+		'',
+		'Open the page below and write a short, useful summary (3–5 sentences) that:',
+		'- says what is actually on this page — roles, projects, technologies and dates, named specifically rather than described in adjectives',
+		'- draws out what that says about him as an engineer, and where his depth really is',
+		'- ends with one concrete next step available on the site: another page, a project, or a way to reach him',
+		'',
+		'Format it as 2–3 short paragraphs. Tone: direct and factual, second person ("you"). Skip generic praise — let the work speak.',
+		'',
+		`Page: “${page}” — ${url}`,
+		description ? `In short: ${description}` : null,
+		`Site overview: ${SITE_ORIGIN}/llms.txt`,
+	]
+		.filter((line) => line !== null)
+		.join('\n');
+}
+
+/** The heading above the icon row. */
+export const labels = {
+	en: {
+		heading: 'Summarise this page with AI',
+		/** `%s` is the assistant's name. */
+		action: 'Summarise this page with %s',
+	},
+	de: {
+		heading: 'Diese Seite mit KI zusammenfassen',
+		action: 'Diese Seite mit %s zusammenfassen',
+	},
+} as const;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -23,6 +23,12 @@ export const BLOG_URL = 'https://blog.gnadlinger.me/';
 export const BRAND = 'Gnadlinger';
 export const FULL_NAME = 'Johannes Gnadlinger';
 
+/** Fallback `<title>` and description for pages that set neither. Shared so
+ *  the head and the AI prompt below the fold describe the same page. */
+export const DEFAULT_TITLE = `${BRAND} — ${FULL_NAME}, Backend Engineer`;
+export const DEFAULT_DESCRIPTION =
+	'Johannes Gnadlinger — Backend Engineer for corporate payment systems and financial infrastructure, based in Linz, Austria.';
+
 export type JsonLdNode = Record<string, unknown>;
 
 /** Absolute URL for a page path — matches the `<link rel="canonical">` value. */

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,6 +8,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 	description="404 — this page does not exist."
 	alternates={false}
 	noindex
+	askAi={false}
 >
 	<Hero title="Page not found" tagline="This page doesn’t exist. Try the navigation above." />
 </BaseLayout>

--- a/src/pages/de/404.astro
+++ b/src/pages/de/404.astro
@@ -8,6 +8,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 	description="404 — diese Seite existiert nicht."
 	alternates={false}
 	noindex
+	askAi={false}
 >
 	<Hero
 		title="Seite nicht gefunden"


### PR DESCRIPTION
A row of assistant links sits above the footer on every content page. Each
one opens ChatGPT, Claude, Google AI Mode or Perplexity with a prompt
already in the input: it names the page, quotes its description, and points
at llms.txt so the answer is grounded in this site rather than in whatever
the model remembers about the surname.

The prompt is built per page and per language, so the German pages hand over
a German prompt. It travels in the query string, which keeps the whole thing
static — no JavaScript ships for it.

Title and description defaults move into schema.ts so the head and the
prompt cannot drift apart. The 404s opt out; there is nothing to summarise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QTCjVBspWYAFNW1e8peZxJ